### PR TITLE
various performance and memory optimization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,10 +7,12 @@ version = "0.2.5"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+TiledIteration = "06e1c1a7-607b-532d-9fad-de7d9aa2abac"
 
 [compat]
 ImageCore = "0.8.1, 0.9"
 OffsetArrays = "1"
+TiledIteration = "0.3"
 julia = "1"
 
 [extras]

--- a/src/DitherPunk.jl
+++ b/src/DitherPunk.jl
@@ -1,6 +1,8 @@
 module DitherPunk
 
 using ImageCore
+using TiledIteration
+using ImageCore.MappedArrays
 using Random
 using OffsetArrays
 

--- a/src/colorspaces.jl
+++ b/src/colorspaces.jl
@@ -1,19 +1,11 @@
 """
 Convert from sRGB to linear color space.
 """
-srgb2linear(u::Gray)::Gray = u ≤ 0.04045 ? 25 * u / 323 : ((200 * u + 11) / 211)^(12 / 5)
-srgb2linear(img::AbstractMatrix{<:Gray}) = srgb2linear.(img)
-function srgb2linear!(img::AbstractMatrix{<:Gray})
-    img .= srgb2linear.(img)
-    return nothing
-end
+@inline srgb2linear(u::Number) = Colors.invert_srgb_compand(u)
+@inline srgb2linear(u::Gray) = typeof(u)(srgb2linear(gray(u)))
 
 """
 Convert from linear to sRGB color space.
 """
-linear2srgb(u::Gray)::Gray = u ≤ 0.0031308 ? 323 * u / 25 : (211 * u^(5 / 12) - 11) / 200
-linear2srgb(img::AbstractMatrix{<:Gray}) = linear2srgb.(img)
-function linear2srgb!(img::AbstractMatrix{<:Gray})
-    img .= linear2srgb.(img)
-    return nothing
-end
+@inline linear2srgb(u::Number) = Colors.srgb_compand(u)
+@inline linear2srgb(u::Gray) = typeof(u)(linear2srgb(gray(u)))

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -4,3 +4,10 @@ if isdefined(OffsetArrays, :OffsetMatrix)
 else
     const OffsetMatrix{T} = OffsetArrays.OffsetArray{T,2}
 end
+
+if VERSION < v"1.1"
+    # newly added in https://github.com/JuliaLang/julia/pull/30630
+    require_one_based_indexing(A...) = !Base.has_offset_axes(A...) || throw(ArgumentError("offset arrays are not supported but got an array with index other than 1"))
+else
+    using Base: require_one_based_indexing
+end

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -6,6 +6,8 @@ else
 end
 
 if VERSION >= v"1.1"
+    # I:J syntax for CartesianIndex is newly introduced in
+    # https://github.com/JuliaLang/julia/pull/29440
     _colon(a::CartesianIndex, b::CartesianIndex) = a:b
 else
     _colon(a::CartesianIndex, b::CartesianIndex) = CartesianIndices(map(UnitRange, a.I, b.I))

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -4,3 +4,9 @@ if isdefined(OffsetArrays, :OffsetMatrix)
 else
     const OffsetMatrix{T} = OffsetArrays.OffsetArray{T,2}
 end
+
+if VERSION >= v"1.1"
+    _colon(a::CartesianIndex, b::CartesianIndex) = a:b
+else
+    _colon(a::CartesianIndex, b::CartesianIndex) = CartesianIndices(map(UnitRange, a.I, b.I))
+end

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -4,11 +4,3 @@ if isdefined(OffsetArrays, :OffsetMatrix)
 else
     const OffsetMatrix{T} = OffsetArrays.OffsetArray{T,2}
 end
-
-if VERSION >= v"1.1"
-    # I:J syntax for CartesianIndex is newly introduced in
-    # https://github.com/JuliaLang/julia/pull/29440
-    _colon(a::CartesianIndex, b::CartesianIndex) = a:b
-else
-    _colon(a::CartesianIndex, b::CartesianIndex) = CartesianIndices(map(UnitRange, a.I, b.I))
-end

--- a/src/error_diffusion.jl
+++ b/src/error_diffusion.jl
@@ -2,7 +2,7 @@ function error_diffusion(
     img::AbstractMatrix{<:Gray}, stencil::OffsetMatrix; to_linear=false
 )::BitMatrix
     # this function does not yet support OffsetArray
-    Base.require_one_based_indexing(img)
+    require_one_based_indexing(img)
 
     # Change from normalized intensities to Float as error will get added!
     FT = floattype(eltype(img))

--- a/src/error_diffusion.jl
+++ b/src/error_diffusion.jl
@@ -27,7 +27,7 @@ function error_diffusion(
 
         # Diffuse "error" to neighborhood in stencil
         err = convert(FT, px - rnd) # type stable
-        RO = max(p+first(O), first(R)):min(p+last(O), last(R))
+        RO = _colon(max(p+first(O), first(R)), min(p+last(O), last(R)))
         isempty(RO) && continue
         for po in RO
             _img[po] += err * stencil[po-p]

--- a/src/error_diffusion.jl
+++ b/src/error_diffusion.jl
@@ -16,7 +16,7 @@ function error_diffusion(
     O = CartesianIndices(stencil)
     R = CartesianIndices(_img)
     i_first, i_last = first(R), last(R)
-    for p in CartesianIndices(_img)
+    @inbounds for p in R
         px = _img[p]
 
         # Round to closest color
@@ -27,7 +27,7 @@ function error_diffusion(
 
         # Diffuse "error" to neighborhood in stencil
         err = convert(FT, px - rnd) # type stable
-        RO = _colon(max(p+first(O), first(R)), min(p+last(O), last(R)))
+        RO = _colon(max(p+first(O), i_first), min(p+last(O), i_last))
         isempty(RO) && continue
         for po in RO
             _img[po] += err * stencil[po-p]

--- a/src/ordered.jl
+++ b/src/ordered.jl
@@ -30,9 +30,9 @@ function ordered_dithering(
             # so that original `img` data is not modified.
             out[R...] .= @views img[R...] .> mat
         else # boundary condition
-            mat_inds = CartesianIndices(mat_size)
-            out_inds = CartesianIndices(map(getindex, R, mat_inds.indices))
-            out[out_inds] .= @views img[out_inds] .> mat[mat_inds]
+            mat_inds = map(Base.OneTo, mat_size)
+            out_inds = map(getindex, R, mat_inds)
+            out[out_inds...] .= @views img[out_inds...] .> mat[mat_inds...]
         end
     end
     return out

--- a/src/ordered.jl
+++ b/src/ordered.jl
@@ -23,7 +23,7 @@ function ordered_dithering(
     out = BitMatrix(undef, size(img)...)
     # TODO: add Threads.@threads to this for loop further improves the performances
     #       but it has unidentified memory allocations
-    @inbounds for R in TileIterator(axes(img), size(mat))
+    for R in TileIterator(axes(img), size(mat))
         mat_size = map(length, R)
         if mat_size == size(mat)
             # `mappedarray` creates a readonly wrapper with lazy evaluation with `srgb2linear`

--- a/src/ordered.jl
+++ b/src/ordered.jl
@@ -23,7 +23,7 @@ function ordered_dithering(
     out = BitMatrix(undef, size(img)...)
     # TODO: add Threads.@threads to this for loop further improves the performances
     #       but it has unidentified memory allocations
-    for R in TileIterator(axes(img), size(mat))
+    @inbounds for R in TileIterator(axes(img), size(mat))
         mat_size = map(length, R)
         if mat_size == size(mat)
             # `mappedarray` creates a readonly wrapper with lazy evaluation with `srgb2linear`

--- a/src/ordered.jl
+++ b/src/ordered.jl
@@ -10,30 +10,32 @@ Optionally, this final threshold map can be inverted by selecting `invert_map=tr
 function ordered_dithering(
     img::AbstractMatrix{<:Gray}, mat::AbstractMatrix; to_linear=false, invert_map=false
 )::BitMatrix
-    # Create full threshold map by repeating threshold matrix `mat` in x and y directions
-    h, w = size(img)
-    threshold = tile_matrix(mat, h, w)
+    # eagerly promote to the same eltype to make for-loop faster
+    FT = floattype(eltype(img))
+    if invert_map
+        mat = @. FT(1 - mat)
+    else
+        mat = FT.(mat)
+    end
+    linear_fun = to_linear ? srgb2linear : identity
+    img = @. FT.(linear_fun.(img))
 
-    # Optionally cast to linear colorspace
-    _img = copy(img)
-    to_linear && srgb2linear!(_img)
-
-    # Optionally invert map ∈ [0, 1]
-    invert_map && (threshold .= 1 .- threshold)
-
-    return _img .> threshold
-end
-
-"""
-    tile_matrix(mat, h, w)
-
-Repeatedly tile a smaller matrix `mat` to fill out an image of height `h` and width `w`.
-"""
-function tile_matrix(mat, h, w)
-    h_mat, w_mat = size(mat)
-    repeat_rows = ceil(Int, h / h_mat)
-    repeat_cols = ceil(Int, w / w_mat)
-    return view(repeat(mat, repeat_rows, repeat_cols), 1:h, 1:w) # view matching image dims
+    out = BitMatrix(undef, size(img)...)
+    # TODO: add Threads.@threads to this for loop further improves the performances
+    #       but it has unidentified memory allocations
+    @inbounds for R in TileIterator(axes(img), size(mat))
+        mat_size = map(length, R)
+        if mat_size == size(mat)
+            # `mappedarray` creates a readonly wrapper with lazy evaluation with `srgb2linear`
+            # so that original `img` data is not modified.
+            out[R...] .= @views img[R...] .> mat
+        else # boundary condition
+            mat_inds = CartesianIndices(mat_size)
+            out_inds = CartesianIndices(map(getindex, R, mat_inds.indices))
+            out[out_inds] .= @views img[out_inds] .> mat[mat_inds]
+        end
+    end
+    return out
 end
 
 """

--- a/src/threshold.jl
+++ b/src/threshold.jl
@@ -5,10 +5,7 @@ function threshold_dithering(
         DimensionMismatch("Arguments img and threshold_map need to have same dimensions"),
     )
 
-    # Optionally cast to linear colorspace
-    _img = copy(img)
-    to_linear && srgb2linear!(_img)
-
+    to_linear && (img = mappedarray(srgb2linear, img))
     return img .> threshold_map
 end
 


### PR DESCRIPTION
The result visually looks "correct" to me so a double-check would be the best, @adrhill it would be better if you can write some correctness test in the future.

```julia
using DitherPunk
using TestImages, ImageTransformations, ImageShow, ImageCore

img = imresize(testimage("cameraman"), (240, 240))

@btime bayer_dithering($img);
# master: 1.490 ms (15 allocations: 969.02 KiB)
# PR: 187.368 μs (15 allocations: 233.62 KiB)

@btime bayer_dithering($img, to_linear=true);
# master: 3.190 ms (15 allocations: 969.02 KiB)
# PR: 279.525 μs (15 allocations: 233.62 KiB)


@btime simple_error_diffusion($img);
# master: 743.018 μs (4 allocations: 232.31 KiB)
# PR: 702.736 μs (5 allocations: 232.41 KiB)

@btime simple_error_diffusion($img, to_linear=true);
# master: 1.753 ms (4 allocations: 232.31 KiB)
# PR: 766.562 μs (5 allocations: 232.41 KiB)


@btime threshold_dithering($img, to_linear=true);
# master: 1.784 ms (7 allocations: 180.39 KiB)
# PR: 155.320 μs (19 allocations: 12.34 KiB)
```