### PR TITLE
fix Julia 1.0 resolver issue

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,6 +34,16 @@ jobs:
             ${{ runner.os }}-test-
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
+      # Pkg version resolver is not smart enough for old Julia versions
+      - name: "Compat fix for Julia < v1.3.0"
+        if: ${{ matrix.version == '1.0' }}
+        run: |
+          using Pkg
+          Pkg.add([
+            PackageSpec(name="Images", version="0.23"),
+            PackageSpec(name="ImageCore", version="0.8"),
+          ])
+        shell: julia --project=. --startup=no --color=yes {0}
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1

--- a/Project.toml
+++ b/Project.toml
@@ -20,10 +20,11 @@ julia = "1"
 [extras]
 ImageInTerminal = "d8c32880-2388-543b-8c61-d9f865259254"
 Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
+ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [targets]
-test = ["ImageInTerminal", "Images", "ReferenceTests", "Test", "TestImages", "UnicodePlots"]
+test = ["ImageInTerminal", "Images", "ImageMagick", "ReferenceTests", "Test", "TestImages", "UnicodePlots"]

--- a/src/colorspaces.jl
+++ b/src/colorspaces.jl
@@ -17,7 +17,7 @@ Return color in ColorScheme `cs` that is closest to `color`
 function closest_color(
     color::Colorant, cs::AbstractVector{<:Colorant}; metric=DE_2000()
 )::Colorant
-    imin = argmin(colordiff.(color, cs; metric))
+    imin = argmin(colordiff.(color, cs; metric=metric))
     return cs[imin]
 end
 

--- a/src/error_diffusion.jl
+++ b/src/error_diffusion.jl
@@ -35,7 +35,7 @@ function dither(
             px = _img[r, c]
 
             # Round to closest color
-            col = closest_color(px, cs; metric)
+            col = closest_color(px, cs; metric=metric)
 
             # Apply pixel to dither
             dither[r, c] = col
@@ -70,7 +70,7 @@ function dither(
 )
     # Construct grayscale color scheme of length `steps`
     cs = [Gray(i) for i in range(0.0, 1.0; length=steps)]
-    d = dither(img, alg, cs; metric, kwargs...)
+    d = dither(img, alg, cs; metric=metric, kwargs...)
     if steps == 2
         # match return type of other binary dithering algorithms
         return Gray{Bool}.(d)


### PR DESCRIPTION
The target branch of this PR is #13 (not master)

- Pkg version resolver is not smart enough to figure out a possible Manifest.toml in some cases. Here we manually set the versions for old Julia CI targets.
- `; metric` as a syntax sugar only exists in new Julia versions, so for backward compatibility, I changed it to `; metric=metric`.